### PR TITLE
[feat] Apply manifest when application CRD creates

### DIFF
--- a/api/v1/application_types.go
+++ b/api/v1/application_types.go
@@ -144,8 +144,8 @@ type ApplicationDestination struct {
 	// Namespace specifies the target namespace for the application's resources.
 	// The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
 	Namespace string `json:"namespace,omitempty"`
-	// Name specifies the target cluster's name
-	Name string `json:"name"`
+	// Name specifies the target cluster's name. Do not enter any value if you want to deploy in current context.
+	Name string `json:"name,omitempty"`
 }
 
 // TODO

--- a/config/crd/bases/cd.tmax.io_applications.yaml
+++ b/config/crd/bases/cd.tmax.io_applications.yaml
@@ -41,15 +41,14 @@ spec:
                   and namespace
                 properties:
                   name:
-                    description: Name specifies the target cluster's name
+                    description: Name specifies the target cluster's name. Do not
+                      enter any value if you want to deploy in current context.
                     type: string
                   namespace:
                     description: Namespace specifies the target namespace for the
                       application's resources. The namespace will only be set for
                       namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
-                required:
-                - name
                 type: object
               source:
                 description: Source is a reference to the location of the application's

--- a/config/samples/cd_v1_application.yaml
+++ b/config/samples/cd_v1_application.yaml
@@ -3,5 +3,9 @@ kind: Application
 metadata:
   name: application-sample
 spec:
-  # Add fields here
-  foo: bar
+  source:
+    repoURL: "https://github.com/tmax-cloud/cd-example-apps"
+    path: "guestbook/guestbook-ui-svc.yaml"
+    targetRevision: "main"
+  destination:
+    namespace: default

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -28,6 +28,7 @@ import (
 
 	cdv1 "github.com/tmax-cloud/cd-operator/api/v1"
 	"github.com/tmax-cloud/cd-operator/internal/utils"
+	"github.com/tmax-cloud/cd-operator/pkg/manifestmanager"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -103,6 +104,18 @@ func (r *ApplicationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		if err := r.Client.Status().Patch(ctx, instance, p); err != nil {
 			log.Error(err, "")
 			return ctrl.Result{}, err
+		}
+		mgr := manifestmanager.ManifestManager{Client: r.Client}
+		urls, err := mgr.GetManifestURLList(instance)
+		if err != nil {
+			log.Error(err, "")
+			return ctrl.Result{}, err
+		}
+		for _, url := range urls {
+			if err = mgr.ApplyManifest(url, instance); err != nil {
+				log.Error(err, "")
+				return ctrl.Result{}, err
+			}
 		}
 	}
 


### PR DESCRIPTION
- Add applymanifest in application reconcile loop
-  Remove current context checking logic when apply manifests
- If user does not enter destination name, deploy at current cluster
- Create app-named namespace for deployResources